### PR TITLE
examples.rs: Remove pattern thickness from DiagonalPattern to fix number of args

### DIFF
--- a/tachyonfx-ftl-web/src/examples.rs
+++ b/tachyonfx-ftl-web/src/examples.rs
@@ -454,7 +454,7 @@ mod basic {
 
                 fx::paint(fg, bg, 1000)
                     .with_area(content_area)
-                    .with_pattern(DiagonalPattern::bottom_left_to_top_right(1))
+                    .with_pattern(DiagonalPattern::bottom_left_to_top_right())
             "},
             canvas: canvas::DEFAULT,
         }


### PR DESCRIPTION
examples.rs: Remove pattern thickness from DiagonalPattern to fix `Invalid number of arguments. Expected 0, got 1`